### PR TITLE
Fixing creation of stacks in regions supported by AmazonConnect [CC-2222]

### DIFF
--- a/aws-cft/contact-center-cft
+++ b/aws-cft/contact-center-cft
@@ -1,5 +1,13 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "Configuration": {
+            "S3": {
+                "BucketPrefix": "uipath-contactcenter",
+                "LambdaKeysLocation": "AmazonConnect/IVR/"
+            }
+        }
+    },
     "Parameters": {
         "OrchestratorUrl": {
             "Type": "String",
@@ -491,8 +499,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": "uipath-contactcenter",
-                    "S3Key": "AmazonConnect/IVR/UiPathContactCenterAuthenticate.zip"
+                    "S3Bucket": { "Fn::Join": [ "-", [ { "Fn::FindInMap": [ "Configuration", "S3", "BucketPrefix" ] }, { "Ref": "AWS::Region" } ] ] },
+                    "S3Key": { "Fn::Join": [ "", [ { "Fn::FindInMap": [ "Configuration", "S3", "LambdaKeysLocation" ] }, "UiPathContactCenterAuthenticate.zip" ] ] }
                 },
                 "Handler": "authenticate.handler",
                 "Runtime": "nodejs12.x",
@@ -534,8 +542,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": "uipath-contactcenter",
-                    "S3Key": "AmazonConnect/IVR/UiPathContactCenterStartJob.zip"
+                    "S3Bucket": { "Fn::Join": [ "-", [ { "Fn::FindInMap": [ "Configuration", "S3", "BucketPrefix" ] }, { "Ref": "AWS::Region" } ] ] },
+                    "S3Key": { "Fn::Join": [ "", [ { "Fn::FindInMap": [ "Configuration", "S3", "LambdaKeysLocation" ] }, "UiPathContactCenterStartJob.zip" ] ] }
                 },
                 "Handler": "startJob.handler",
                 "Runtime": "nodejs12.x",
@@ -577,8 +585,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": "uipath-contactcenter",
-                    "S3Key": "AmazonConnect/IVR/UiPathContactCenterQueryJob.zip"
+                    "S3Bucket": { "Fn::Join": [ "-", [ { "Fn::FindInMap": [ "Configuration", "S3", "BucketPrefix" ] }, { "Ref": "AWS::Region" } ] ] },
+                    "S3Key": { "Fn::Join": [ "", [ { "Fn::FindInMap": [ "Configuration", "S3", "LambdaKeysLocation" ] }, "UiPathContactCenterQueryJob.zip" ] ] }
                 },
                 "Handler": "queryJob.handler",
                 "Runtime": "nodejs12.x",
@@ -776,8 +784,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": "uipath-contactcenter",
-                    "S3Key": "AmazonConnect/IVR/UiPathContactCenterPackInputs.zip"
+                    "S3Bucket": { "Fn::Join": [ "-", [ { "Fn::FindInMap": [ "Configuration", "S3", "BucketPrefix" ] }, { "Ref": "AWS::Region" } ] ] },
+                    "S3Key": { "Fn::Join": [ "", [ { "Fn::FindInMap": [ "Configuration", "S3", "LambdaKeysLocation" ] }, "UiPathContactCenterPackInputs.zip" ] ] }
                 },
                 "Handler": "packInputs.handler",
                 "Runtime": "nodejs12.x",
@@ -881,8 +889,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": "uipath-contactcenter",
-                    "S3Key": "AmazonConnect/IVR/UiPathContactCenterCreateContactFlows.zip"
+                    "S3Bucket": { "Fn::Join": [ "-", [ { "Fn::FindInMap": [ "Configuration", "S3", "BucketPrefix" ] }, { "Ref": "AWS::Region" } ] ] },
+                    "S3Key": { "Fn::Join": [ "", [ { "Fn::FindInMap": [ "Configuration", "S3", "LambdaKeysLocation" ] }, "UiPathContactCenterCreateContactFlows.zip" ] ] }
                 },
                 "Handler": "createContactFlows.handler",
                 "Runtime": "nodejs12.x",
@@ -977,8 +985,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": "uipath-contactcenter",
-                    "S3Key": "AmazonConnect/IVR/UiPathContactCenterQueryRelease.zip"
+                    "S3Bucket": { "Fn::Join": [ "-", [ { "Fn::FindInMap": [ "Configuration", "S3", "BucketPrefix" ] }, { "Ref": "AWS::Region" } ] ] },
+                    "S3Key": { "Fn::Join": [ "", [ { "Fn::FindInMap": [ "Configuration", "S3", "LambdaKeysLocation" ] }, "UiPathContactCenterQueryRelease.zip" ] ] }
                 },
                 "Handler": "queryRelease.handler",
                 "Runtime": "nodejs12.x",


### PR DESCRIPTION
Have modified the CFT as per the inputs from Ram from AWS team. 
Have created buckets in the following regions, which support Amazon Connect and put the lambdas there too:
1. us-east-1
2. us-west-2
3. ap-southeast-1
4. ap-southeast-2
5. ap-northeast-1
6. eu-central-1
7. eu-west-2

I have also tested the stack creation of 2 other regions. It gets built correctly.